### PR TITLE
use string_decoder instead of setEncoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,18 @@
+var StringDecoder = require('string_decoder').StringDecoder;
+
 var requestPayload = function(req, opts, cb) {
   if (typeof opts === 'function') return requestPayload(req, {}, opts);
 
+  var decoder = new StringDecoder('utf-8');
   var buffer = '';
   var length = 0;
   
-  req.setEncoding('utf-8');
   req.on('data', function(data) {
-    if (opts.limit && (length += Buffer.byteLength(data)) > opts.limit) return req.destroy();
-    buffer += data;
+    if (opts.limit && (length += data.length) > opts.limit) return req.destroy();
+    buffer += decoder.write(data);
   });
   req.on('end', function() {
-    cb(buffer);
+    cb(buffer + decoder.end());
   });
 };
 


### PR DESCRIPTION
just spent hours debugging a weird stream issue because this module changed the encoding of a request to utf-8. this pr allocates an explicit utf-8 decoder instead of using the one on the request to still have the request be binary (aka less side effects!).

_disclamer_ i know i originally sent the pr that used `setEncoding` hehe
